### PR TITLE
activate for all frames

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,6 +11,7 @@
       "*://netflix.com/*",
       "*://www.netflix.com/*"
     ],
+    "all_frames": true,
     "js": ["content_script.js"],
     "run_at": "document_start"
   }],


### PR DESCRIPTION
This will fix the plugin for special cases like [truedread/netflix-1080p#53](https://github.com/truedread/netflix-1080p/issues/53).