### PR TITLE
Make 5.1 audio work again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+cadmium-playercore-1080p.js text eol=lf

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -6,6 +6,16 @@ urls = [
     'get_manifest.js'
 ]
 
+
+// very messy workaround for accessing chrome storage outside of background / content scripts
+browser.storage.sync.get(['use6Channels'], function(items) {
+    var use6Channels = items.use6Channels;
+    var mainScript = document.createElement('script');
+    mainScript.type = 'application/javascript';
+    mainScript.text = 'var use6Channels = ' + use6Channels + ';';
+    document.documentElement.appendChild(mainScript);
+});
+
 for (var i = 0; i < urls.length; i++) {
     var mainScriptUrl = chrome.extension.getURL(urls[i]);
 

--- a/src/get_manifest.js
+++ b/src/get_manifest.js
@@ -66,7 +66,7 @@ var profiles = [
 ];
 
 
-if(window.use6Channels)
+if(use6Channels)
     profiles.push("heaac-5.1-dash");
 
 var messageid = Math.floor(Math.random() * 2**52);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,18 @@
     "*://assets.nflxext.com/*/ffe/player/html/*",
     "*://www.assets.nflxext.com/*/ffe/player/html/*",
     "*://netflix.com/*",
-    "*://www.netflix.com/*"
-  ]
+    "*://www.netflix.com/*",
+    "storage"
+  ],
+
+  "options_ui": {
+    "page": "options.html"
+  },
+
+  "applications": {
+    "gecko": {
+      "id": "netflix-1080p-firefox@vladikoff"
+    }
+  }
+
 }

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            margin: 2em 3em;
+        }
+        .pref-box {
+            display: block;
+            margin: 1em 0;;
+        }
+        label, input {
+            line-height: 150%;
+        }
+    </style>        
+</head>
+
+<body>
+    <div class="pref-box">
+        <label>
+            <input type="checkbox" id="5.1">Use 5.1 audio when available</input>
+        </label>
+    </div>
+
+    <div id="status"></div>
+    
+    <div class="pref-box">
+        <button id="save">Save</button>
+    </div>
+
+    <script src="options.js"></script>
+</body>
+
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,35 @@
+function save_options(e) {
+    e.preventDefault();
+    var use6Channels = document.getElementById('5.1').checked;
+    // var setMaxBitrate = document.getElementById('setMaxBitrate').checked;
+    browser.storage.sync.set({
+        use6Channels: use6Channels,
+        // setMaxBitrate: setMaxBitrate
+    }, function() {
+        var status = document.getElementById('status');
+        status.textContent = 'Options saved.';
+        setTimeout(function() {
+            status.textContent = '';
+        }, 750);
+    });
+}
+
+function restore_options() {
+    function setCurrentChoice(result) {
+        document.getElementById('5.1').checked = result.use6Channels;
+        // document.getElementById('setMaxBitrate').checked = result.setMaxBitrate;
+    }
+    function onError(error) {
+        console.log(`Error: ${error}`);
+    }
+
+    var getting = browser.storage.sync.get({
+        use6Channels: false,
+        // setMaxBitrate: false
+    });
+    getting.then(setCurrentChoice, onError);
+
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);


### PR DESCRIPTION
Add rudimentary but functional Firefox options panel with checkbox to offer 5.1 audio if available.  The options panel is accessible by clicking on Netflix 1080p in the about:addons list.  (There is still no toolbar icon.)  

Other than changing a few keywords to Firefox API, this PR is mostly adapted straight from the truedread extension.  See the Commit comment for further details.  I was able to test and confirm that 5.1 audio now works with this extension and Firefox 69 (only if enabled in options, of course).  Could close Issue #22 if others can verify.  

This opens the door for someone else to implement the Max Bitrate setting and add it to the options panel.  I didn't understand truedread's code for that option so I omitted it.